### PR TITLE
Strip unchanged accounts out of StateUpdate call

### DIFF
--- a/core/state/plugin_hooks.go
+++ b/core/state/plugin_hooks.go
@@ -1,12 +1,20 @@
 package state
 
 import (
+	"bytes"
 	"fmt"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/plugins"
+	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/core/state/snapshot"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/openrelayxyz/plugeth-utils/core"
+	"time"
+)
+
+var (
+	acctCheckTimer = metrics.NewRegisteredTimer("plugeth/statedb/accounts/checks", nil)
 )
 
 type pluginSnapshot struct {
@@ -29,7 +37,8 @@ func (s *pluginSnapshot) Storage(accountHash, storageHash common.Hash) ([]byte, 
 	return nil, fmt.Errorf("not implemented")
 }
 
-func PluginStateUpdate(pl *plugins.PluginLoader, blockRoot, parentRoot common.Hash, destructs map[common.Hash]struct{}, accounts map[common.Hash][]byte, storage map[common.Hash]map[common.Hash][]byte, codeUpdates map[common.Hash][]byte) {
+func PluginStateUpdate(pl *plugins.PluginLoader, blockRoot, parentRoot common.Hash, snap snapshot.Snapshot, trie Trie, destructs map[common.Hash]struct{}, accounts map[common.Hash][]byte, storage map[common.Hash]map[common.Hash][]byte, codeUpdates map[common.Hash][]byte) {
+	checker := &acctChecker{snap, trie}
 	fnList := pl.Lookup("StateUpdate", func(item interface{}) bool {
 		_, ok := item.(func(core.Hash, core.Hash, map[core.Hash]struct{}, map[core.Hash][]byte, map[core.Hash]map[core.Hash][]byte, map[core.Hash][]byte))
 		return ok
@@ -39,9 +48,13 @@ func PluginStateUpdate(pl *plugins.PluginLoader, blockRoot, parentRoot common.Ha
 		coreDestructs[core.Hash(k)] = v
 	}
 	coreAccounts := make(map[core.Hash][]byte)
+	start := time.Now()
 	for k, v := range accounts {
-		coreAccounts[core.Hash(k)] = v
+		if checker.updated(k, v) {
+			coreAccounts[core.Hash(k)] = v
+		}
 	}
+	acctCheckTimer.UpdateSince(start)
 	coreStorage := make(map[core.Hash]map[core.Hash][]byte)
 	for k, v := range storage {
 		coreStorage[core.Hash(k)] = make(map[core.Hash][]byte)
@@ -61,10 +74,51 @@ func PluginStateUpdate(pl *plugins.PluginLoader, blockRoot, parentRoot common.Ha
 	}
 }
 
-func pluginStateUpdate(blockRoot, parentRoot common.Hash, destructs map[common.Hash]struct{}, accounts map[common.Hash][]byte, storage map[common.Hash]map[common.Hash][]byte, codeUpdates map[common.Hash][]byte) {
+func pluginStateUpdate(blockRoot, parentRoot common.Hash, snap snapshot.Snapshot, trie Trie, destructs map[common.Hash]struct{}, accounts map[common.Hash][]byte, storage map[common.Hash]map[common.Hash][]byte, codeUpdates map[common.Hash][]byte) {
 	if plugins.DefaultPluginLoader == nil {
 		log.Warn("Attempting StateUpdate, but default PluginLoader has not been initialized")
 		return
 	}
-	PluginStateUpdate(plugins.DefaultPluginLoader, blockRoot, parentRoot, destructs, accounts, storage, codeUpdates)
+	PluginStateUpdate(plugins.DefaultPluginLoader, blockRoot, parentRoot, snap, trie, destructs, accounts, storage, codeUpdates)
+}
+
+
+type acctChecker struct {
+	snap snapshot.Snapshot
+	trie Trie
+}
+
+func (ac *acctChecker) updated(k common.Hash, v []byte) bool {
+	if updated, ok := ac.snapUpdated(k, v); ok {
+		return updated
+	}
+	return ac.trieUpdated(k, v)
+}
+
+func (ac *acctChecker) snapUpdated(k common.Hash, v []byte) (bool, bool) {
+	acct, err := ac.snap.AccountRLP(k)
+	if err != nil {
+		return false, false
+	}
+	if len(acct) == 0 {
+		return false, false
+	}
+	return !bytes.Equal(acct, v), true
+}
+
+type acctByHasher interface {
+	GetAccountByHash(common.Hash) (*types.StateAccount, error)
+}
+
+func (ac *acctChecker) trieUpdated(k common.Hash, v []byte) bool {
+	trie, ok := ac.trie.(acctByHasher)
+	if !ok {
+		log.Warn("Couldn't check trie updates, wrong trie type")
+		return true
+	}
+	oAcct, err := trie.GetAccountByHash(k)
+	if err != nil {
+		return true
+	}
+	return !bytes.Equal(v, snapshot.SlimAccountRLP(oAcct.Nonce, oAcct.Balance, oAcct.Root, oAcct.CodeHash))
 }

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1523,7 +1523,7 @@ func (s *StateDB) Commit(deleteEmptyObjects bool) (common.Hash, error) {
 		// Only update if there's a state transition (skip empty Clique blocks)
 		if parent := s.snap.Root(); parent != root {
 			//begin PluGeth code injection
-			pluginStateUpdate(root, parent, s.convertAccountSet(s.stateObjectsDestruct), s.snapAccounts, s.snapStorage, codeUpdates)
+			pluginStateUpdate(root, parent, s.snap, s.trie, s.convertAccountSet(s.stateObjectsDestruct), s.snapAccounts, s.snapStorage, codeUpdates)
 			if _, ok := s.snap.(*pluginSnapshot); !ok && s.snaps != nil { // This if statement (but not its content) was added by PluGeth
 			//end PluGeth injection
 				if err := s.snaps.Update(root, parent, s.convertAccountSet(s.stateObjectsDestruct), s.snapAccounts, s.snapStorage); err != nil {


### PR DESCRIPTION
When the parallel executor runs, fewer accounts are marked as changed than when the serial executor runs, which seems to come back to reverts where something got marked as dirty, but changed back to its original state.

In general it doesn't matter whether these accounts are sent or not, but we need consistency across nodes, and because some nodes might complete a block serially while others complete it in parallel, they produce different account lists, which can cause problems downstream.